### PR TITLE
Add return_value => 'dump' for Data::Printer

### DIFF
--- a/t/97dataprinter.t
+++ b/t/97dataprinter.t
@@ -25,7 +25,7 @@ use if !eval{ require Data::Printer },
 
 use Test::More;
 
-use Data::Printer colored => 0;
+use Data::Printer colored => 0, return_value => 'dump';
 use MooX::Struct Something => [qw( $foo bar )];
 
 my $obj = Something->new(foo => 1, bar => 2);


### PR DESCRIPTION
This is required as of version 0.36 of Data::Printer, where the default for
return_value changed from 'dump' to 'pass'. Since we rely on getting the dump
back, we need to tell Data::Printer that
